### PR TITLE
docs(mkdocs): set dark mode as default and fix theme configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,17 +7,17 @@ repo_name: ben-alkov/mcp-registry-client
 theme:
   name: material
   palette:
+    - scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to light mode
     - scheme: default
       primary: blue
       accent: blue
       toggle:
         icon: material/brightness-4
-        name: Switch to light mode
-    - scheme: light
-      primary: blue
-      accent: blue
-      toggle:
-        icon: material/brightness-7
         name: Switch to dark mode
   features:
     - navigation.tabs


### PR DESCRIPTION
## Summary
- Set dark mode (`slate` scheme) as the default theme
- Fix theme configuration where second scheme was incorrectly set to `light` instead of `default`
- Correct toggle icon directions for better user experience
- Users can now toggle between dark (default) and light modes

## Changes
- Changed first palette scheme from `default` to `slate` (dark mode)
- Changed second palette scheme from `light` to `default` (light mode) 
- Fixed toggle icons: `brightness-7` for switching to light mode, `brightness-4` for switching to dark mode
- Reordered palettes so dark mode loads first

## Test plan
- [x] Build documentation locally with `mkdocs serve`
- [x] Verify dark mode loads by default
- [x] Test theme toggle functionality works correctly
- [x] Confirm toggle icons display proper direction/intent

🤖 Generated with [Claude Code](https://claude.ai/code)